### PR TITLE
Drop setuptools from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "actinia-grassdata-management-plugin"
-version = "1.0.0"
+version = "1.0.1"
 description = "An actinia-core plugin which adds vector- raster and STRDS enpoints to actinia-core"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ dependencies = [
     "actinia-processing-lib>=1.1.0",
     "Flask>=3.0.0",
     "pwgen",
-    "setuptools==80.10.2",
     "werkzeug>=3.1.3",
 ]
 


### PR DESCRIPTION
setuptools is (at least should not be) not a runtime dependency, however with a specific version pinned, it causes a version conflict with actinia-core==7.1.1
Therefore I suggest to remove it from dependencies (also from other plugins).